### PR TITLE
Add https://wordpress.com (when logged in)

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,4 @@ to fork this and add a site.
 * http://kylefiedler.com/
 * https://obsidian.charlespeters.net/
 * http://ricardoerl.com/
+* https://wordpress.com (when logged in)


### PR DESCRIPTION
The WordPress Control Panel (on both wordpress.com and self-hosted
WordPress) now uses only system fonts. See
https://make.wordpress.org/core/2016/07/07/native-fonts-in-4-6/
